### PR TITLE
Fix repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["crhino <piraino.chris@gmail.com>"]
 description = "Task runner, thread pools, multi-producer, multi-consumer queues, oh my! This is a crate with helpers for building concurrent software easily and safely."
 
 readme = "./README.md"
-repository = "https://github.com/crhino/transit"
+repository = "https://github.com/crhino/ferrous-threads"
 keywords = ["concurrency", "threads"]
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
Hi,

I saw that the link was wrong pointing to transit (another project that you also own). I discovered that search in crates.io ( https://crates.io/search?page=3&q=thread ) and that use the repository to link (so I went to the wrong repo)